### PR TITLE
Set paranoid option on Model. This paranoid flag comes by sluOptions parameter

### DIFF
--- a/lib/sequelize-slugify.js
+++ b/lib/sequelize-slugify.js
@@ -44,6 +44,10 @@ SequelizeSlugify.prototype.slugifyModel = function (Model, slugOptions) {
                 });
             }
         }
+
+        if(slugOptions && typeof slugOptions.paranoid === 'boolean') {
+            Model.options.paranoid = slugOptions.paranoid;
+        }
         
         return Model.find({
             where,


### PR DESCRIPTION
The purpose of this pr is to allow sequelize to consider column 'deleted_at' in query execution. The flag "paranoid" is passed by parameter in 'slugOptions'. This flag is informed in Model.
